### PR TITLE
Added 'viewBox' and 'preserveAspectRatio' to the svg created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Creates a gauge appended to the given DOM element.
   - label {String} that appears in the top portion of the gauge
   - clazz {String} class to apply to the gauge element in order to support custom styling
   - size {Number} the over all size (radius) of the gauge
+  - preserveAspectRatio {String} default 'xMinYMin meet', see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
   - min {Number} the minimum value that the gauge measures
   - max {Number} the maximum value that the gauge measures
   - majorTicks {Number} the number of major ticks to draw

--- a/d3-gauge.js
+++ b/d3-gauge.js
@@ -43,6 +43,7 @@ var proto = Gauge.prototype;
  *  - label {String} that appears in the top portion of the gauge
  *  - clazz {String} class to apply to the gauge element in order to support custom styling
  *  - size {Number} the over all size (radius) of the gauge
+ *  - preserveAspectRatio {String} default 'xMinYMin meet', see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
  *  - min {Number} the minimum value that the gauge measures
  *  - max {Number} the maximum value that the gauge measures
  *  - majorTicks {Number} the number of major ticks to draw 
@@ -68,6 +69,8 @@ function Gauge (el, opts) {
 
   this._cx     =  this._size / 2;
   this._cy     =  this._cx;
+
+  this._preserveAspectRatio = this._opts.preserveAspectRatio;
 
   this._min    =  this._opts.min;
   this._max    =  this._opts.max;
@@ -171,6 +174,8 @@ proto._initGauge = function () {
     .attr('class'  ,  'd3-gauge' + (this._clazz ? ' ' + this._clazz : ''))
     .attr('width'  ,  this._size)
     .attr('height' ,  this._size)
+    .attr('viewBox',  '0 0 ' + this._size + ' ' + this._size)
+    .attr('preserveAspectRatio', this._preserveAspectRatio || 'xMinYMin meet')
 }
 
 proto._drawOuterCircle = function () {


### PR DESCRIPTION
Added 'viewBox' and 'preserveAspectRatio' to the svg created, allowing dynamic scaling the size of it.

An option 'preserveAspectRatio' was added allowing customizing the scaling behavior. By default,
'xMinYMin meet' is used for 'preserveAspectRatio'.
