### PR TITLE
refreshRange() and _initZones little fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Writes a value to the gauge and updates its state, i.e. needle position, accordi
 - value *Number* the new gauge value, should be in between min and max
 - transitionDuration *Number* (optional) transition duration, if not supplied the configured duration is used
 
+###*gauge.refreshRange = function(maxValue, minValue)*
+
+Refreshes the zones and the ticks without removing and rendering the whole gauge.
+This method is meant to be used when your max/min data could change dynamically.
+@name refreshRange
+@function
+**params:**
+
+- maxValue *Number* (optional) Max. If not passed it'll use value from _opts.max
+- minValue *Number* (optional) Min.
+
 ## Styling
 
 d3-gauge can be custom styled and none of the features are visible if no style is included at all.

--- a/d3-gauge.js
+++ b/d3-gauge.js
@@ -135,6 +135,27 @@ proto.write = function(value, transitionDuration) {
     .duration(transitionDuration ? transitionDuration : this._transitionDuration)
     .attrTween('transform', transition);
 }
+/**
+ * Refreshes the zones and the ticks without removing and rendering the whole gauge.
+ * This method is meant to be used when your max/min data could change dynamically.
+ * @name refreshRange
+ * @param maxValue {Number} (optional) Max. Optional only if you would like to go back to _opts.max
+ * @param minValue {Number} (optional) Min.
+ */
+proto.refreshRange = function(maxValue, minValue) {
+	this._min = minValue ? minValue : this._opts.min;
+	this._max = maxValue ? maxValue : this._opts.max;
+	this._range = this._max - this._min;
+	
+	this._initZones();
+	this._drawZones();
+	
+	this._gauge.select('.major-tick-label[text-anchor="start"]').remove();
+	this._gauge.select('.major-tick-label[text-anchor="end"]').remove();
+	this._drawTicks();
+	
+	return this;
+};
 
 proto._initZones = function () {
   var self = this;
@@ -152,7 +173,7 @@ proto._initZones = function () {
   }
 
   // create new zones to not mess with the passed in args
-  this._zones = this._zones.map(initZone);
+  this._zones = this._opts.zones.map(initZone);
 }
 
 proto._render = function () {


### PR DESCRIPTION
Hi,

i was working in something using your code and, well first of all, thanks for the code, and faced that one of the gauges could be changing the range since the max value is a memory usage counter so, i wrote the refreshRange method, and im sharing it. include it on your code as you consider. 

while working on that, i found that _initZones method could contain a bug cause you commented it as "create new zones to not mess with the passed in args" but with the code in your branch it will be getting the {from,to} values already set in the gauge, so the initial proportion set by user for yellow/red zones becomes messed.

hope this work for you, and thanks for the code.
